### PR TITLE
♻️ Update toolVersion to 1.22.0 & Remove deprecated failFast property

### DIFF
--- a/config/quality/quality.gradle
+++ b/config/quality/quality.gradle
@@ -19,8 +19,7 @@ task ktlint(type: JavaExec, group: "verification") {
 }
 
 detekt {
-    failFast = false
-    toolVersion = "1.14.1"
+    toolVersion = "1.22.0"
     def configFile = new File(rootDir, 'detekt-config.yml')
     if (!configFile.exists()) {
         new URL('https://raw.githubusercontent.com/Hipo/macaron/master/config/quality/detekt-config.yml')


### PR DESCRIPTION
`failFast` is deprecated and needs to be removed in order to update detekt version to `2.22.0`